### PR TITLE
feat: split provider docs into separate files

### DIFF
--- a/docs/content/_meta.js
+++ b/docs/content/_meta.js
@@ -1,6 +1,10 @@
 export default {
-  index: "",
-  techstack: "",
-  "style-guides": "",
-  testing: "",
+  index: 'Home',
+  introduction: 'Introduction',
+  guides: 'Guides',
+  reference: 'Reference',
+  techstack: 'Tech Stack',
+  'style-guides': 'Style Guides',
+  testing: 'Testing',
+  tutorials: 'Tutorials',
 };

--- a/docs/content/guides/_meta.js
+++ b/docs/content/guides/_meta.js
@@ -1,0 +1,5 @@
+export default {
+  'getting-started': 'Getting Started',
+  'advanced-topics': 'Advanced Topics',
+  'third-party-services': 'Third-Party Services',
+};

--- a/docs/content/guides/advanced-topics.mdx
+++ b/docs/content/guides/advanced-topics.mdx
@@ -1,0 +1,6 @@
+# Advanced Topics
+
+Add deeper guides or workflows here.
+
+## Customization
+Explain how to extend or customize the project.

--- a/docs/content/guides/getting-started.mdx
+++ b/docs/content/guides/getting-started.mdx
@@ -1,0 +1,11 @@
+# Getting Started
+
+Use this guide to set up the project locally.
+
+## Prerequisites
+- List software requirements here.
+
+## Installation
+1. Clone the repository
+2. Install dependencies
+3. Run the development server

--- a/docs/content/guides/third-party-services/_meta.js
+++ b/docs/content/guides/third-party-services/_meta.js
@@ -1,0 +1,5 @@
+export default {
+  index: 'Overview',
+  'payment-service': 'Payment Service',
+  'analytics-service': 'Analytics Service',
+};

--- a/docs/content/guides/third-party-services/analytics-service.mdx
+++ b/docs/content/guides/third-party-services/analytics-service.mdx
@@ -1,0 +1,19 @@
+# Analytics Service
+
+Instructions for integrating the analytics provider.
+
+## Setup
+1. Install the SDK:
+   ```bash
+   pnpm add analytics-service
+   ```
+2. Set the `ANALYTICS_API_KEY` environment variable.
+
+## Usage Example
+```ts
+import { AnalyticsSDK } from 'analytics-service';
+
+export const analyticsClient = new AnalyticsSDK({
+  apiKey: process.env.ANALYTICS_API_KEY,
+});
+```

--- a/docs/content/guides/third-party-services/index.mdx
+++ b/docs/content/guides/third-party-services/index.mdx
@@ -1,0 +1,33 @@
+# Third-Party Services Integration
+
+This section explains how to work with external providers such as payment gateways, analytics platforms or authentication services. Each provider has its own guide so you can keep credentials and setup steps isolated.
+
+## Selecting a Service
+- Evaluate the reliability and pricing of the provider.
+- Confirm compatibility with your tech stack.
+
+## Installation and Setup
+1. Install the provider's SDK or library.
+2. Configure required environment variables and credentials.
+3. Follow the provider's documentation for any initial setup.
+
+## Working with Multiple Providers
+When you rely on more than one service, create a separate module for each provider and keep configuration isolated. Wrapper classes can expose a unified interface to the rest of your codebase.
+
+```ts
+import { PaymentSDK } from 'payment-service';
+import { AnalyticsSDK } from 'analytics-service';
+
+export const paymentClient = new PaymentSDK({
+  apiKey: process.env.PAYMENT_API_KEY,
+});
+
+export const analyticsClient = new AnalyticsSDK({
+  apiKey: process.env.ANALYTICS_API_KEY,
+});
+```
+
+## Best Practices
+- Securely store API keys and secrets in environment variables.
+- Keep third-party dependencies updated.
+- Handle errors gracefully and provide fallbacks.

--- a/docs/content/guides/third-party-services/payment-service.mdx
+++ b/docs/content/guides/third-party-services/payment-service.mdx
@@ -1,0 +1,19 @@
+# Payment Service
+
+This guide shows how to integrate the payment provider.
+
+## Setup
+1. Install the SDK:
+   ```bash
+   pnpm add payment-service
+   ```
+2. Create required environment variables, e.g. `PAYMENT_API_KEY`.
+
+## Usage Example
+```ts
+import { PaymentSDK } from 'payment-service';
+
+export const paymentClient = new PaymentSDK({
+  apiKey: process.env.PAYMENT_API_KEY,
+});
+```

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -1,3 +1,11 @@
-# Introduction
+# Project Documentation
 
-Updating...
+Welcome to the project documentation. Use the navigation on the left to browse each section.
+
+- **Introduction** – project overview and goals
+- **Guides** – setup and step-by-step instructions
+- **Third-Party Services** – provider guides for external services
+- **Reference** – detailed API and configuration
+- **Style Guides** – coding conventions
+- **Testing** – how to run tests
+- **Tutorials** – practical walkthroughs

--- a/docs/content/introduction/index.mdx
+++ b/docs/content/introduction/index.mdx
@@ -1,0 +1,9 @@
+# Introduction
+
+Provide a brief overview of the project, its goals and the key stakeholders.
+
+## Scope
+Describe the high-level scope of the project.
+
+## Objectives
+List the main objectives and deliverables.

--- a/docs/content/reference/_meta.js
+++ b/docs/content/reference/_meta.js
@@ -1,0 +1,3 @@
+export default {
+  'api-reference': 'API Reference',
+};

--- a/docs/content/reference/api-reference.mdx
+++ b/docs/content/reference/api-reference.mdx
@@ -1,0 +1,6 @@
+# API Reference
+
+Document your API endpoints and data models here.
+
+## Example Endpoint
+Describe the endpoint, parameters and responses.

--- a/docs/content/testing/_meta.js
+++ b/docs/content/testing/_meta.js
@@ -1,3 +1,4 @@
 export default {
-  "api-tests": "API Tests",
+  'unit-testing': 'Unit Testing',
+  'api-tests': 'API Tests',
 };

--- a/docs/content/testing/unit-testing.mdx
+++ b/docs/content/testing/unit-testing.mdx
@@ -1,0 +1,6 @@
+# Unit Testing
+
+Describe how to write and run unit tests for the project.
+
+## Running Tests
+Provide the commands needed to run the tests.

--- a/docs/content/tutorials/_meta.js
+++ b/docs/content/tutorials/_meta.js
@@ -1,0 +1,3 @@
+export default {
+  'first-steps': 'First Steps',
+};

--- a/docs/content/tutorials/first-steps.mdx
+++ b/docs/content/tutorials/first-steps.mdx
@@ -1,0 +1,6 @@
+# First Steps Tutorial
+
+Walk through a simple example to get familiar with the project.
+
+1. Follow step one
+2. Continue with step two


### PR DESCRIPTION
## Summary
- move third-party integration guide into its own folder
- add separate docs for payment and analytics services
- list new guides via `_meta.js`
- update main index description

## Testing
- `pnpm lint` *(fails: network restrictions prevent downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_684d89a78c9c8329ba975ba4ee905a98