### PR TITLE
fix: fill style guide meta labels

### DIFF
--- a/docs/content/style-guides/_meta.js
+++ b/docs/content/style-guides/_meta.js
@@ -1,7 +1,7 @@
 export default {
-  "branch-conventions": "",
-  "commit-conventions": "",
-  typescript: "",
-  "naming-cheatsheet": "",
-  "clean-code-typescript": "",
+  "branch-conventions": "Branch Conventions",
+  "commit-conventions": "Commit Conventions",
+  typescript: "TypeScript",
+  "naming-cheatsheet": "Naming Cheatsheet",
+  "clean-code-typescript": "Clean Code TypeScript",
 };


### PR DESCRIPTION
## Summary
- label Style Guides entries with proper titles

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684d9555b36883298b3ce334f317a767